### PR TITLE
Add Themed Icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Fixes #321.

Tested on Android 13 (classic + Themed) and Android 10 (classic only, no regression).

### Screenshots

<img src=https://user-images.githubusercontent.com/33295590/213815446-02db6f3e-ead0-4f7b-aa7e-6443b96e7b1c.jpg width=35%>  <img src=https://user-images.githubusercontent.com/33295590/213815438-f87bae8c-7dbb-4e00-a2a6-4d4f40d56d5d.jpg width=35%>
